### PR TITLE
[wip] ci: build securedrop rc packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,15 @@ common-steps:
         echo $PKG_NAME > ~/packaging/sd_package_name
         echo 'export PKG_NAME=$(cat ~/packaging/sd_package_name)' >> $BASH_ENV
 
+  - &clone_and_build_securedrop_core
+    run:
+      name: Clone and build SecureDrop core repository
+      command: |
+        git clone https://github.com/freedomofpress/securedrop.git
+        cd securedrop
+        git checkout $BUILD_TAG
+        make build-debs-notest
+
   - &updatedebianchangelog
     run:
       name: Update debian changelog
@@ -80,6 +89,38 @@ common-steps:
         export PKG_VERSION=$VERSION_TO_BUILD
         make $PKG_NAME
         ls ~/debbuild/packaging/*.deb
+
+  - &set_build_variables
+    run:
+      name: For tag-triggered build, extract the project to build and the tag to build.
+      command: |
+        export CIRCLE_TAG=$TEST_CIRCLE_TAG  # REMOVE ME, FOR TESTING ONLY
+
+        # Extract BUILD_PROJECT and BUILD_TAG
+        export BUILD_PROJECT=$(echo $CIRCLE_TAG | cut -f1 -d/)
+        export BUILD_TAG=$(echo $CIRCLE_TAG | cut -f2 -d/)
+
+        # Enable access to these variables in subsequent run steps
+        echo $BUILD_PROJECT > ~/build_project
+        echo $BUILD_TAG > ~/build_tag
+        echo 'export BUILD_PROJECT=$(cat ~/build_project)' >> $BASH_ENV
+        echo 'export BUILD_TAG=$(cat ~/build_tag)' >> $BASH_ENV
+
+  - &bail_if_not_securedrop_core
+    run:
+      name: Exit build job if BUILD_PROJECT is not securedrop-core (or if BUILD_TAG is not set).
+      command: |
+        if [[ ! $BUILD_PROJECT == "securedrop-core" ]]; then 
+          echo "BUILD_PROJECT is not securedrop-core, skipping"
+          exit 0  # Skip job but don't fail
+        fi
+
+        if [ -n "$BUILD_TAG" ]; then
+          echo "Will build $BUILD_PROJECT on tag $BUILD_TAG"
+        else
+          echo "Expected format of tag to trigger builds is BUILD_PROJECT/BUILD_TAG, exiting"
+          exit 1  # If BUILD_TAG is not set, fail the job because the RM set the CIRCLE_TAG incorrectly
+        fi
 
 version: 2.1
 jobs:
@@ -133,11 +174,25 @@ jobs:
       - *updatedebianchangelog
       - *builddebianpackage
 
+  build-securedrop-core:
+    docker:
+      - image: circleci/python:3.5-stretch
+    environment:
+      TEST_CIRCLE_TAG: securedrop-core/0.14.0-rc1 # For testing. A variable will be in place (CIRCLE_TAG) when we trigger this job on tag push
+    steps:
+      - checkout
+      - *set_build_variables
+      - *bail_if_not_securedrop_core  # In the future we will trigger other builds based on tag push
+      - run: sudo apt-get install -y enchant python-dev rsync
+      - setup_remote_docker
+      - *clone_and_build_securedrop_core
+
 workflows:
   build-debian-packages:
     jobs:
       - build-securedrop-client
       - build-securedrop-proxy
+      - build-securedrop-core
 
   nightly:
     triggers:

--- a/README.md
+++ b/README.md
@@ -48,6 +48,34 @@ Summarizing release manager steps:
 2. Do a test build following steps below
 3. Make any changes as necessary and create a PR into the repository to be packaged with the modifications from steps 1-3
 4. Push the release tag for use in building
+5. For a release candidate or alpha (pre-production) release, push the tag as described in the section below to trigger the build pipeline. For a production release, you should ask the person with production access to build the package and push.
+
+## Automated Builds
+
+The build and deployment of packages for release candidates, alpha releases, and nightlies is done via Circle CI. 
+
+### Nightly
+
+Nighly builds occur at 5 UTC (10 PM Pacific time) for:
+
+* `securedrop-proxy`
+* `securedrop-client`
+
+These packages will appear on `apt-test-qubes.freedom.press`
+
+### Release Candidates and Alpha Releases
+
+#### Workstation
+
+TK
+
+These packages will appear on `apt-test-qubes.freedom.press`.
+
+#### Core
+
+To trigger a build of packages corresponding to a release tag (rc or otherwise) which will be automatically deployed to `apt-test.freedom.press`, push a tag to _this_ repository containing `securedrop-core/BUILD_TAG` where `BUILD_TAG` is the tag you want the packages to be built on in the target repository.
+
+Note that only packages with the same versions but modified checksums will not be committed.
 
 ## Build a package
 


### PR DESCRIPTION
After #64 (automatic nightly build/push of client/proxy), then we can do #63 (automatic build/push of core release candidates), this is work towards that, putting up wip in case anyone has strong feelings on this

Remaining tasks:
 - Reuse steps in #64 and commit only _untracked files_ (to handle the fact that the deploy logic (correctly) doesn't republish packages with unchanged versions but changed checksums) to `core/xenial/` instead of `workstation/stretch/`
 - Add [tag filter](https://circleci.com/docs/2.0/workflows/#executing-workflows-for-a-git-tag) to trigger `build-securedrop-core` only on `securedrop-core/*` tag push (off for now while testing, the behavior in circle is that it will add the tag to `$CIRCLE_TAG` which you'll see is being used in the below diff)