### PR TITLE
Update references to this repo

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/package_addition.md
+++ b/.github/PULL_REQUEST_TEMPLATE/package_addition.md
@@ -18,5 +18,5 @@ _Which packages are you adding, and why?_
 - Security:
   - [ ] A [diff review][review-docs] was performed for all build dependencies
 
-  [ci]: https://app.circleci.com/pipelines/github/freedomofpress/securedrop-debian-packaging
+  [ci]: https://app.circleci.com/pipelines/github/freedomofpress/securedrop-builder
   [review-docs]: https://github.com/freedomofpress/securedrop/wiki/Dependency-specification-and-update-policies

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # SecureDrop Debian Packaging
 
-[![CircleCI](https://circleci.com/gh/freedomofpress/securedrop-debian-packaging/tree/main.svg?style=svg)](https://circleci.com/gh/freedomofpress/securedrop-debian-packaging/tree/main)
+[![CircleCI](https://circleci.com/gh/freedomofpress/securedrop-builder/tree/main.svg?style=svg)](https://circleci.com/gh/freedomofpress/securedrop-builder/tree/main)
 
 This repository contains the packaging files and tooling for building Debian packages for projects for the [SecureDrop Workstation](https://github.com/freedomofpress/securedrop-workstation) based on Qubes OS. Development/staging packages are placed on `apt-test.freedom.press` for installation in Debian-based TemplateVMs, and production packages are placed on `apt.freedom.press`. Please note that the SecureDrop Workstation is currently in a limited beta phase and not yet recommended for general use.
 
@@ -82,7 +82,7 @@ Remember that the following steps needs to be done from the same virtual environ
 
 ### 1. Create updated build-requirements.txt for the project
 
-From the `securedrop-debian-packaging` directory,
+From the `securedrop-builder` directory,
 
 ```shell
 PKG_DIR=/home/user/code/securedrop-client make requirements
@@ -147,7 +147,7 @@ Summarizing release manager steps, at a high level, for changes into this reposi
 7. Build tarballs, and create a detached signature with the release key
 8. Copy your build logs into your project's corresponding directory in the `build-logs` repository, and push your changes to the `main` branch, see https://github.com/freedomofpress/build-logs/commit/fc0eb9551678c8f58ea0017f1eb291375ea5bd9e for example.
 9. Commit these tarballs in the `tarballs/` directory
-10. Open a PR to the `securedrop-debian-packaging` repository with a test plan to verify the checksum in the build logs and tarball signature. The reviewer can perform verification by running:
+10. Open a PR to the `securedrop-builder` repository with a test plan to verify the checksum in the build logs and tarball signature. The reviewer can perform verification by running:
 
 ```shell
 sha256sum <package>.tar.gz
@@ -188,8 +188,8 @@ Clone this repository for access to the packaging tooling.
 
 ```shell
 cd ..
-git clone git@github.com:freedomofpress/securedrop-debian-packaging.git
-cd securedrop-debian-packaging
+git clone git@github.com:freedomofpress/securedrop-builder.git
+cd securedrop-builder
 ```
 
 If you are releasing a new version (rather than rebuilding a package from a previous version),
@@ -255,8 +255,8 @@ Clone this repository for access to the packaging tooling.
 
 ```shell
 cd ..
-git clone git@github.com:freedomofpress/securedrop-debian-packaging.git
-cd securedrop-debian-packaging
+git clone git@github.com:freedomofpress/securedrop-builder.git
+cd securedrop-builder
 ```
 
 If you are releasing a new version (rather than rebuilding a package from a previous version),

--- a/scripts/generate-tag-message
+++ b/scripts/generate-tag-message
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Utility script to generate a signed tag for the packaging repo:
 #
-#   https://github.com/freedomofpress/securedrop-debian-packaging
+#   https://github.com/freedomofpress/securedrop-builder
 #
 # Collects "version" field from package changelogs and prepares a summary
 # commit message when incrementing the tag.
@@ -19,7 +19,7 @@ if [[ $# != 1 ]]; then
 fi
 
 new_version="$1"
-printf 'securedrop-debian-packaging %s\n\n' "$new_version"
+printf 'securedrop-builder %s\n\n' "$new_version"
 # Inspect all changelogs, prepare a pretty list of packages & versions
 for pkg in securedrop-*; do
     pkg_version="$(dpkg-parsechangelog -SVersion --file "${pkg}/debian/changelog-buster" | perl -npE 's/\+buster$//')"

--- a/securedrop-keyring/debian/control
+++ b/securedrop-keyring/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: SecureDrop Team <securedrop@freedom.press>
 Build-Depends: debhelper-compat (= 11),
 Standards-Version: 3.9.8
-Homepage: https://github.com/freedomofpress/securedrop-debian-packaging
+Homepage: https://github.com/freedomofpress/securedrop-builder
 
 Package: securedrop-keyring
 Architecture: all

--- a/securedrop-keyring/debian/copyright
+++ b/securedrop-keyring/debian/copyright
@@ -1,6 +1,6 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: securedrop-keyring
-Source: https://github.com/freedomofpress/securedrop-debian-packaging
+Source: https://github.com/freedomofpress/securedrop-builder
 
 Files: *
 Copyright: 2020 Freedom of the Press Foundation <securedrop@freedom.press>

--- a/securedrop-workstation-config/debian/copyright
+++ b/securedrop-workstation-config/debian/copyright
@@ -1,6 +1,6 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: securedrop-workstation-config
-Source: https://github.com/freedomofpress/securedrop-debian-packaging
+Source: https://github.com/freedomofpress/securedrop-builder
 
 Files: *
 Copyright: 2020 Freedom of the Press Foundation <securedrop@freedom.press>

--- a/securedrop-workstation-viewer/debian/control
+++ b/securedrop-workstation-viewer/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: SecureDrop Team <securedrop@freedom.press>
 Build-Depends: debhelper-compat (= 11),
 Standards-Version: 3.9.8
-Homepage: https://github.com/freedomofpress/securedrop-debian-packaging
+Homepage: https://github.com/freedomofpress/securedrop-builder
 
 Package: securedrop-workstation-viewer
 Architecture: all

--- a/securedrop-workstation-viewer/debian/copyright
+++ b/securedrop-workstation-viewer/debian/copyright
@@ -1,6 +1,6 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: securedrop-workstation-svs-disp
-Source: https://github.com/freedomofpress/securedrop-debian-packaging
+Source: https://github.com/freedomofpress/securedrop-builder
 
 Files: *
 Copyright: 2020 Freedom of the Press Foundation <securedrop@freedom.press>


### PR DESCRIPTION
Towards #304 

In several places in docs or control/copyright files we refer or link directly to this repo. Update occurences of `securedrop-debian-packaging` to `securedrop-builder`.

This does not touch `securedrop-debian-packaging-guide` which looks like it is hosted on RTD without a securedrop.org domain. Should we think about bringing it into the static-hosting-on-k8s fold, @eloquence, or not necessary?

I've verified that the CircleCI links have worked since yesterday, but I haven't actually used the script to generate a tag to sign - does someone want to review that?