### PR TITLE
Rename desktop entry after freedesktop specifications

### DIFF
--- a/securedrop-client/debian/securedrop-client.install
+++ b/securedrop-client/debian/securedrop-client.install
@@ -5,5 +5,5 @@ alembic/script.py.mako usr/share/securedrop-client/alembic/
 alembic/versions/*.py usr/share/securedrop-client/alembic/versions/
 files/sd-app-qubes-gpg-domain.sh etc/profile.d/
 files/securedrop-client usr/bin/
-files/securedrop-client.desktop usr/share/applications/
+files/press.freedom.SecureDropClient.desktop usr/share/applications/
 files/usr.bin.securedrop-client /etc/apparmor.d/


### PR DESCRIPTION
## Description

This is  follow up on https://github.com/freedomofpress/securedrop-client/pull/1589 and https://github.com/freedomofpress/securedrop-client/pull/1600, that ensures that the file name that's referred to by the SecureDrop Client application is the one that's installed when installing the application.

:crystal_ball: **Reviewers**: the CI pipeline will need to be triggered again after https://github.com/freedomofpress/securedrop-client/pull/1600 is merged. Failures are expected before that.

## Test plan

- [ ] The CI pipeline succeeds (especially the `build-bullseye-securedrop-client` and `build-bookworm-securedrop-client` jobs)