### PR TITLE
Add script to simplify promoting packages from dev to prod

### DIFF
--- a/scripts/promote-suite
+++ b/scripts/promote-suite
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""
+Promote a suite of packages to the prod repository
+
+This expects you have a directory layout like the following:
+.
+├── securedrop-builder (this repository)
+├── securedrop-dev-packages-lfs (contains packages to promote)
+└── securedrop-debian-packages-lfs (where packages should be promoted to)
+
+Example:
+    ./promote-suite workstation/bullseye
+
+"""
+import argparse
+import functools
+import shutil
+import subprocess
+from collections import defaultdict
+from pathlib import Path
+from typing import Tuple
+
+from debian import debfile
+
+BUILDER = Path(__name__).absolute().parent
+DEV_LFS = BUILDER.parent / 'securedrop-dev-packages-lfs'
+PROD_LFS = BUILDER.parent / 'securedrop-debian-packages-lfs'
+
+
+def sort_versions(one: Tuple[str, Path], two: Tuple[str, Path]):
+    """sort two Debian package versions"""
+    status = subprocess.run(['dpkg', '--compare-versions', one[0], 'lt', two[0]])
+    if status.returncode == 1:
+        # false, two is bigger
+        return 1
+    else:
+        # true, one is bigger
+        return -1
+
+
+def fix_name(name: str) -> str:
+    """
+    Linux packages embed the version in the name, so we'd never have multiple
+    packages meet the deletion threshold. Silly string manipulation to drop
+    the version.
+    E.g. "linux-image-5.15.26-grsec-securedrop" -> "linux-image-securedrop"
+    """
+    if name.endswith(('-securedrop', '-workstation')):
+        suffix = name.split('-')[-1]
+    else:
+        return name
+    if name.startswith('linux-image-'):
+        return f'linux-image-{suffix}'
+    elif name.startswith('linux-headers-'):
+        return f'linux-headers-{suffix}'
+    return name
+
+
+def suite_info(path: Path):
+    # Get the latest package + version for each package in the suite
+    ret = {}
+    data = defaultdict(dict)
+    for deb in path.glob('*.deb'):
+        control = debfile.DebFile(deb).control.debcontrol()
+        name = fix_name(control['Package'])
+        if 'rc' in control['Version']:
+            # We never want to promote rc packages
+            continue
+        data[name][control['Version']] = deb
+
+    for name, versions in data.items():
+        items = sorted(versions.items(), key=functools.cmp_to_key(sort_versions), reverse=True)
+        ret[name] = items[0][1]
+
+    return ret
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Cleans up old packages"
+    )
+    parser.add_argument(
+        "suite",
+        help="Suite to promote",
+    )
+    args = parser.parse_args()
+    dev_folder = DEV_LFS / args.suite
+    prod_folder = PROD_LFS / args.suite
+    for folder in [dev_folder, prod_folder]:
+        if not folder.is_dir():
+            raise RuntimeError(f"Directory {folder}, doesn't exist")
+
+    dev_suite = suite_info(dev_folder)
+    prod_suite = suite_info(prod_folder)
+    to_promote = []
+    for name, dev_path in dev_suite.items():
+        try:
+            prod_path = prod_suite[name]
+            # XXX: for simplicity we use a simple equality check, assuming
+            # it's unlikely for the dev repo to be behind the prod repo.
+            if dev_path.name != prod_path.name:
+                to_promote.append(dev_path)
+        except KeyError:
+            # Not in prod repo yet
+            to_promote.append(dev_path)
+
+    for dev_path in sorted(to_promote):
+        print(f'Promoting {dev_path.name}')
+        prod_path = prod_folder / dev_path.name
+        shutil.copy2(dev_path, prod_path)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
The new `./scripts/promote-suite` simplifies the process of promoting packages from the dev repository to the prod one.

The primary use case currently is for promoting Tor and Linux packages.

For each package in the dev repo, it compares the highest version to the highest version in the prod repo, copying over the dev package if they don't match. There are some edge cases where this doesn't work (which is annotated with a code comment), but it should get the majority correct.

As a side-effect, it could reveal when a package in dev was forgotten for promotion to prod.

In the future this script could be fancier by showing debdiffs and diffoscopes of the newly promoted packages, or a dry-run mode that shows which packages are pending promotion.

I've wanted to do this for a while, mostly motivated today because yesterday I screwed up copying the Tor debs over and got annoyed.

## Test plan

* [x] Set up the directory layout as documented if you already don't have it that way
* [x] Check out 195e260cdd1228f07354f5068f3c8fb8b98de24f ("Remove buster distribution") in the securedrop-debian-packages-lfs repository
* [x] Run `./scripts/promote-suite core/focal`, observe the following output:
```
Promoting linux-headers-5.15.81-grsec-securedrop_5.15.81-grsec-securedrop-1_amd64.deb
Promoting linux-image-5.15.81-grsec-securedrop_5.15.81-grsec-securedrop-1_amd64.deb
Promoting securedrop-grsec_5.15.81-grsec-securedrop-1_amd64.deb
Promoting tor-geoipdb_0.4.7.12-1~focal+1_all.deb
Promoting tor_0.4.7.12-1~focal+1_amd64.deb
```
* [x] Look in the securedrop-debian-packages-lfs and verify the packages were copied correctly