### PR TITLE
Create issues when a new Tor release is fetched

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ jobs:
 
   reprepro-update-tor:
     docker:
-      - image: debian:bullseye
+      - image: debian:bullseye-backports
     steps:
       - checkout
       - *addsshkeys
@@ -174,7 +174,8 @@ jobs:
           name: clone and run reprepro update
           command: |
             apt-get update
-            apt-get install -y reprepro ca-certificates dctrl-tools git git-lfs openssh-client
+            apt-get install -y reprepro ca-certificates dctrl-tools git git-lfs openssh-client \
+                gh python3
 
             # Clone the dev repo and configure it
             git clone git@github.com:freedomofpress/securedrop-dev-packages-lfs.git
@@ -193,7 +194,8 @@ jobs:
             mv repo/pool/main/t/tor/*.deb core/focal/
             git add core/focal/*.deb
             # If there are changes, diff-index will fail, so we commit and push
-            git diff-index --quiet HEAD || git commit -m "Automatically updating Tor packages" && git push origin main
+            git diff-index --quiet HEAD || git commit -m "Automatically updating Tor packages" \
+                && git push origin main && ../scripts/new-tor-issue
 
 
   build: &build

--- a/scripts/new-tor-issue
+++ b/scripts/new-tor-issue
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""
+Creates a new issue to track Tor updates or appends a comment
+to any existing issues
+"""
+
+import json
+import random
+import subprocess
+import tempfile
+
+REPOSITORY = "freedomofpress/securedrop"
+# TODO: Add more
+SALUTATIONS = ["Aloha", "Bonjour", "Ciao", "Dear human overlords"]
+TEMPLATE = """\
+{salutation},
+
+A new Tor update is available.
+
+Details should be available on the [Tor forum](https://forum.torproject.net/c/news/tor-release-announcement/28).
+
+<details><summary>Here is the commit I just pushed to
+apt-test:</summary>
+
+```diff
+{patch}
+```
+</details>
+
+* [x] CI adds new packages to apt-test
+* [ ] Install tor, tor-geoipdb packages from apt-test on a prod
+      install and let them sit overnight
+* [ ] Verify that tor is still running after reboot, services
+      available, no errors or unexpected messages in logs
+* [ ] Submit a PR to `securedrop-debian-packages-lfs` to deploy
+      the same packages
+
+P.S.  This issue was created by `scripts/new-tor-issue` via the CI job `reprepro-update-tor`.
+"""
+TITLE = "New Tor update available"
+
+
+def main():
+    patch = subprocess.check_output(["git", "format-patch", "HEAD~1", "--stdout"]).decode().strip()
+    # Query open issues to see if there's a task already open
+    existing = json.loads(subprocess.check_output(
+        ["gh", "issue", "list", "-R", REPOSITORY,
+         "-S", TITLE, "--json", "title,number"]
+    ))
+    with tempfile.TemporaryFile("w") as message:
+        message.write(TEMPLATE.format(salutation=random.choice(SALUTATIONS), patch=patch))
+        message.seek(0)
+        for issue in existing:
+            # Looks like there's already an open issue
+            if issue["title"] == TITLE:
+                subprocess.run(
+                    ["gh", "issue", "comment", "-R", REPOSITORY,
+                     str(issue["number"]), "-F", "-"],
+                    stdin=message, check=True
+                )
+                return
+
+        # Create a new issue
+        subprocess.run(
+            ["gh", "issue", "create", "-R", REPOSITORY,
+             "--title", TITLE, "-F", "-"],
+            stdin=message, check=True
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
CI will now create a new issue (or update an existing one) whenever it fetches new Tor packages. This is something that I have been doing manually for a while now whenever I see a new Tor release announcement.

The generated issue contains the checklist as well as the diff of the new debs so you can see the version and checksums of the packages. An example issue (with the wrong patch) is
<https://github.com/freedomofpress/securedrop/issues/6723>.

Some potential future improvements that I deferred for now is to include the version number in the issue title, and the correct Tor Project forum link.

The script wraps around the official `gh` CLI tool, it needs a GITHUB_TOKEN to be set in the environment to work properly. `gh` is only available in bullseye-backports, so I had to adjust the image so it would be installable.

Of course, if this works out well, I'd like to expand this to other things like kernel and dependency updates.