### PR TITLE
Only run new-tor-issue when we have a new package (for real)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,8 +202,8 @@ jobs:
             mv repo/pool/main/t/tor/*.deb core/focal/
             git add core/focal/*.deb
             # If there are changes, diff-index will fail, so we commit and push
-            git diff-index --quiet HEAD || git commit -m "Automatically updating Tor packages" \
-                && git push origin main && ../scripts/new-tor-issue
+            git diff-index --quiet HEAD || (git commit -m "Automatically updating Tor packages" \
+                && git push origin main && ../scripts/new-tor-issue)
 
 
   build: &build


### PR DESCRIPTION
Follow-up to 1862e178a1abb08.

I wrongly understood how bash grouped || and &&. We wanted `diff-index || (commit && push && new-tor-issue)`, but instead bash gave us `(diff-index || commit) && push && new-tor-issue`, which meant that regardless of whether there is a new package, we were pushing (harmless) and running the new-tor-issue script (disruptive!).

By adding explicit parenthesis it should do what we actually want.