### PR TITLE
Update apt LFS repo names

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,8 +93,8 @@ common-steps:
         apt-get update
         apt-get install -y ca-certificates git git-lfs openssh-client python3 python3-debian
 
-        git clone git@github.com:freedomofpress/securedrop-dev-packages-lfs.git
-        cd securedrop-dev-packages-lfs
+        git clone git@github.com:freedomofpress/securedrop-apt-test.git
+        cd securedrop-apt-test
 
         git config user.email "securedrop@freedom.press"
         git config user.name "sdcibot"
@@ -186,8 +186,8 @@ jobs:
                 gh python3
 
             # Clone the dev repo and configure it
-            git clone git@github.com:freedomofpress/securedrop-dev-packages-lfs.git
-            cd securedrop-dev-packages-lfs
+            git clone git@github.com:freedomofpress/securedrop-apt-test.git
+            cd securedrop-apt-test
             git lfs install
             git config user.email "securedrop@freedom.press"
             git config user.name "sdcibot"

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ sha256sum /path/to/built/package.deb
 
 Save and publish your build logs to the `build-logs` repository, e.g. https://github.com/freedomofpress/build-logs/commit/786eb46672b07b5c635d87a075770b53a0ce3df9
 
-Commit the deb to a new `securedrop-debian-packages-lfs` branch (this will be added as a `git-lfs` object).
+Commit the deb to a new `securedrop-apt-prod` branch (this will be added as a `git-lfs` object).
 
 Commit all new and modified `reprepro` files created via the publish script (`sudo apt install reprepro` if not already installed):
 ```shell

--- a/scripts/clean-old-packages
+++ b/scripts/clean-old-packages
@@ -3,7 +3,7 @@
 Clean up old packages, specifying how many to keep
 
 Example:
-    ./clean-old-packages securedrop-dev-packages-lfs/workstation/buster-nightlies 7
+    ./clean-old-packages securedrop-apt-test/workstation/buster-nightlies 7
 
 """
 import argparse

--- a/scripts/new-tor-issue
+++ b/scripts/new-tor-issue
@@ -32,7 +32,7 @@ apt-test:</summary>
       install and let them sit overnight
 * [ ] Verify that tor is still running after reboot, services
       available, no errors or unexpected messages in logs
-* [ ] Submit a PR to `securedrop-debian-packages-lfs` to deploy
+* [ ] Submit a PR to `securedrop-apt-prod` to deploy
       the same packages
 
 P.S.  This issue was created by `scripts/new-tor-issue` via the CI job `reprepro-update-tor`.

--- a/scripts/promote-suite
+++ b/scripts/promote-suite
@@ -5,8 +5,8 @@ Promote a suite of packages to the prod repository
 This expects you have a directory layout like the following:
 .
 ├── securedrop-builder (this repository)
-├── securedrop-dev-packages-lfs (contains packages to promote)
-└── securedrop-debian-packages-lfs (where packages should be promoted to)
+├── securedrop-apt-test (contains packages to promote)
+└── securedrop-apt-prod (where packages should be promoted to)
 
 Example:
     ./promote-suite workstation/bullseye
@@ -23,8 +23,8 @@ from typing import Tuple
 from debian import debfile
 
 BUILDER = Path(__name__).absolute().parent
-DEV_LFS = BUILDER.parent / 'securedrop-dev-packages-lfs'
-PROD_LFS = BUILDER.parent / 'securedrop-debian-packages-lfs'
+DEV_LFS = BUILDER.parent / 'securedrop-apt-test'
+PROD_LFS = BUILDER.parent / 'securedrop-apt-prod'
 
 
 def sort_versions(one: Tuple[str, Path], two: Tuple[str, Path]):


### PR DESCRIPTION
For https://github.com/freedomofpress/securedrop-builder/issues/304, rename references to the renamed repos in CircleCI configs and scripts. See also https://github.com/freedomofpress/securedrop-builder/pull/400, which makes more updates to documentation -- the change here will be removed by one of those commits, but I left it in for clarity.

We will proceed with the renaming on the GitHub end later today (2023-02-14), but old clones will continue to work.