### PR TITLE
Stop patching dh_virtualenv for Python 3.11+, now fixed

### DIFF
--- a/scripts/install-deps
+++ b/scripts/install-deps
@@ -24,10 +24,6 @@ sudo apt-get install  \
     python3-setuptools \
     desktop-file-utils -y
 
-echo "Patching dh_virtualenv for Python 3.11 support"
-# See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1030170
-sudo sed -i "s/inspect.getargspec/inspect.getfullargspec/" /usr/bin/dh_virtualenv
-
 # Inspect the wheel files present locally. If repo was cloned
 # without git-lfs, they'll be "text/plain", rather than "application/zip".
 wheel_mime_types="$(find workstation-bootstrap/ -type f -iname '*.whl' -exec file --mime-type {} + | perl -F':\s+' -lanE 'say $F[-1]' | sort -u)"


### PR DESCRIPTION
The fixed dh_virtualenv version is now in Debian Bookworm, so we no longer need to patch it ourselves:
* https://tracker.debian.org/news/1418871/accepted-dh-virtualenv-122-13-source-into-unstable/
* https://tracker.debian.org/news/1420883/dh-virtualenv-122-13-migrated-to-testing/

## Test plan
* [x] CI passes