### PR TITLE
Updates for securedrop-client 0.9.0-rc1 build

### DIFF
--- a/scripts/build-debianpackage
+++ b/scripts/build-debianpackage
@@ -151,12 +151,12 @@ if [[ -f "$TOP_BUILDDIR/$PKG_NAME/debian/changelog-$VERSION_CODENAME" ]]; then
     mv "$TOP_BUILDDIR/$PKG_NAME/debian/changelog-$VERSION_CODENAME" "$TOP_BUILDDIR/$PKG_NAME/debian/changelog"
 fi
 if [[ ! -f "$TOP_BUILDDIR/$PKG_NAME/debian/changelog" ]]; then
-    echo "Moving legacy buster changelog into place"
-    mv "$TOP_BUILDDIR/$PKG_NAME/debian/changelog-buster" "$TOP_BUILDDIR/$PKG_NAME/debian/changelog"
+    echo "Moving legacy bullseye changelog into place"
+    mv "$TOP_BUILDDIR/$PKG_NAME/debian/changelog-bullseye" "$TOP_BUILDDIR/$PKG_NAME/debian/changelog"
 fi
 
 # Adjust platform in version number with sed magic to only replace the first instance
-sed -i "0,/buster/s//${VERSION_CODENAME}/" debian/changelog
+sed -i "0,/bullseye/s//${VERSION_CODENAME}/" debian/changelog
 
 # Adds reproducibility step
 SOURCE_DATE_EPOCH="$(dpkg-parsechangelog -STimestamp)"

--- a/scripts/update-changelog
+++ b/scripts/update-changelog
@@ -35,14 +35,14 @@ if [[ -z "${PKG_VERSION:-}" ]]; then
 fi
 
 
-# Look for a changelog as d/changelog-$platform, d/changelog, or d/changelog-buster
+# Look for a changelog as d/changelog-$platform, d/changelog, or d/changelog-bullseye
 if [[ -f "${TOPLEVEL}/${PKG_NAME}/debian/changelog-${VERSION_CODENAME}" ]]; then
     changelog="${TOPLEVEL}/${PKG_NAME}/debian/changelog-${VERSION_CODENAME}"
 else
     if [[ -f "${TOPLEVEL}/${PKG_NAME}/debian/changelog" ]]; then
         changelog="${TOPLEVEL}/${PKG_NAME}/debian/changelog"
     else
-        changelog="${TOPLEVEL}/${PKG_NAME}/debian/changelog-buster"
+        changelog="${TOPLEVEL}/${PKG_NAME}/debian/changelog-bullseye"
     fi
 fi
 

--- a/securedrop-client/debian/changelog-bullseye
+++ b/securedrop-client/debian/changelog-bullseye
@@ -1,0 +1,12 @@
+securedrop-client (0.9.0-rc1+bullseye) unstable; urgency=medium
+
+  * 
+
+ -- SecureDrop Team <securedrop@freedom.press>  Thu, 09 Mar 2023 16:04:19 -0500
+
+securedrop-client (0.8.1+bullseye) unstable; urgency=medium
+
+  * See changelog.md 
+
+ -- SecureDrop Team <securedrop@freedom.press>  Thu, 15 Sep 2022 08:37:55 +1000
+


### PR DESCRIPTION
- updates scripts to reference `changelog-bullseye` instead of `changelog-buster`
- adds changelog entry for securedrop-client 0.9.0-rc1