### PR TITLE
Added changelog for ssecuredrop-client 0.9.0-rc1

### DIFF
--- a/securedrop-client/debian/changelog-buster
+++ b/securedrop-client/debian/changelog-buster
@@ -1,3 +1,9 @@
+securedrop-client (0.9.0-rc1+bullseye) unstable; urgency=medium
+
+  * See changelog.md 
+
+ -- SecureDrop Team <securedrop@freedom.press>  Thu, 09 Mar 2023 17:08:14 -0500
+
 securedrop-client (0.8.1+bullseye) unstable; urgency=medium
 
   * See changelog.md 


### PR DESCRIPTION
- adds securedrop-client 0.9.0-rc1 changelog entry (in legacy changelog-buster file)