### PR TITLE
Add build changes for securedrop-client 0.9.0-rc2

### DIFF
--- a/securedrop-client/debian/changelog-buster
+++ b/securedrop-client/debian/changelog-buster
@@ -1,3 +1,9 @@
+securedrop-client (0.9.0-rc2+bullseye) unstable; urgency=medium
+
+  * see changelog.md 
+
+ -- SecureDrop Team <securedrop@freedom.press>  Mon, 13 Mar 2023 19:23:51 -0400
+
 securedrop-client (0.9.0-rc1+bullseye) unstable; urgency=medium
 
   * See changelog.md 

--- a/securedrop-client/debian/securedrop-client.install
+++ b/securedrop-client/debian/securedrop-client.install
@@ -5,5 +5,6 @@ alembic/script.py.mako usr/share/securedrop-client/alembic/
 alembic/versions/*.py usr/share/securedrop-client/alembic/versions/
 files/sd-app-qubes-gpg-domain.sh etc/profile.d/
 files/securedrop-client usr/bin/
+files/securedrop-client.desktop usr/share/applications/
 files/press.freedom.SecureDropClient.desktop usr/share/applications/
 files/usr.bin.securedrop-client /etc/apparmor.d/


### PR DESCRIPTION
- debian changelog entry for 0.9.0-rc2 added
- `files/securedrop-client.desktop` added back to debian .install file (see securedrop-client#1638)