### PR TITLE
Build securedrop-workstation RPM nightlies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,10 @@ common-steps:
       paths:
         - "*"
 
+  - &attach
+    attach_workspace:
+      at: /tmp/workspace
+
   - &installdeps
     run:
       name: Install Debian packaging dependencies
@@ -274,8 +278,7 @@ jobs:
       CODENAME: bullseye
     steps:
       - checkout
-      - attach_workspace:
-          at: /tmp/workspace
+      - *attach
       - *addsshkeys
       - *commitworkstationdebs
 
@@ -294,11 +297,10 @@ jobs:
       PKG_NAME: << parameters.package >>
     steps:
       - checkout
-      - *addsshkeys
       - run:
           name: Clone and install dependencies
           command: |
-            dnf install git git-lfs make -y
+            dnf install git make -y
             git clone https://github.com/freedomofpress/${PKG_NAME}.git
             cd ${PKG_NAME}
             make install-deps
@@ -307,19 +309,31 @@ jobs:
           command: |
             cd ${PKG_NAME}
             # Version format is "${VERSION}-0.YYYYMMDDHHMMSS.fXX", which sorts lower than "${VERSION}-1"
-            rpmdev-bumpspec --new="$(cat VERSION)-0.$(date +%Y%m%d%H%M%S)%{?dist}" rpm-build/SPECS/${PKG_NAME}.spec
+            rpmdev-bumpspec --new="$(cat VERSION)-0.$(date +%Y%m%d%H%M%S)%{?dist}" rpm-build/SPECS/*.spec
             make build-rpm
+            mkdir -p /tmp/workspace/
+            cp -v rpm-build/RPMS/noarch/*.rpm /tmp/workspace/
+      - *persist
+
+  push-rpm:
+    docker:
+      - image: debian:bullseye
+    steps:
+      - checkout
+      - *attach
+      - *addsshkeys
       - run:
           name: Commit and push
           command: |
-            cd ${PKG_NAME}
+            apt-get update
+            apt-get install -y ca-certificates git git-lfs openssh-client
             git clone git@github.com:freedomofpress/securedrop-yum-test.git
             cd securedrop-yum-test
             git lfs install
             git config user.email "securedrop@freedom.press"
             git config user.name "sdcibot"
             mkdir -p workstation/dom0/f32-nightlies
-            cp -v ../rpm-build/RPMS/noarch/*.rpm workstation/dom0/f32-nightlies/
+            cp -v /tmp/workspace/*.rpm workstation/dom0/f32-nightlies/
             git add .
             # If there are changes, diff-index will fail, so we commit and push
             git diff-index --quiet HEAD || git commit -m "Automated SecureDrop workstation build" && git push origin main
@@ -352,6 +366,12 @@ workflows:
               image:
                 - bullseye
                 - bookworm
+      - build-rpm:
+          matrix:
+            parameters:
+              package: &rpmpackages
+                - securedrop-updater
+                - securedrop-workstation
 
   nightly:
     triggers:
@@ -406,10 +426,12 @@ workflows:
             - push-bullseye
             - build2
             - build2-metapackage
-      # This pushes to a totally separate repository so it can run in parallel
-      # to the debs
       - build-rpm:
           matrix:
             parameters:
-              package:
-                - securedrop-updater
+              package: *rpmpackages
+      # This pushes to a totally separate repository, so it can run in parallel
+      # to the debs
+      - push-rpm:
+          requires:
+            - build-rpm


### PR DESCRIPTION
Closes #456 

Split the actual push operation to a new "push-rpm" job that runs after both the workstation and updater nightlies have been built, following the same pattern for the debs.

Because the "build-rpm" job no longer pushes, we now also run it for each commit to this repository.