### PR TITLE
Bump securedrop-proxy and securedrop-keyring changelogs

### DIFF
--- a/securedrop-keyring/debian/changelog-buster
+++ b/securedrop-keyring/debian/changelog-buster
@@ -1,3 +1,9 @@
+securedrop-keyring (0.1.7+bullseye) unstable; urgency=medium
+
+  * Update release key fingerprint to 2021 key in preinst
+
+ -- SecureDrop Team <securedrop@freedom.press>  Tue, 02 May 2023 16:54:44 +0000
+
 securedrop-keyring (0.1.6+buster) unstable; urgency=medium
 
   * Update public key with new expiration date 

--- a/securedrop-proxy/debian/changelog-buster
+++ b/securedrop-proxy/debian/changelog-buster
@@ -1,3 +1,9 @@
+securedrop-proxy (0.4.1~rc1+bullseye) unstable; urgency=medium
+
+  * See changelog.md
+
+ -- SecureDrop Team <securedrop@freedom.press>  Tue, 02 May 2023 16:53:12 +0000
+
 securedrop-proxy (0.4.0+buster) unstable; urgency=medium
 
   * See changelog.md


### PR DESCRIPTION
Refs #437.
Refs <https://github.com/freedomofpress/securedrop-proxy/issues/116>.