### PR TITLE
Bump securedrop-proxy changelog for 0.4.1 release

### DIFF
--- a/securedrop-proxy/debian/changelog-buster
+++ b/securedrop-proxy/debian/changelog-buster
@@ -1,8 +1,8 @@
-securedrop-proxy (0.4.1~rc1+bullseye) unstable; urgency=medium
+securedrop-proxy (0.4.1+bullseye) unstable; urgency=medium
 
   * See changelog.md
 
- -- SecureDrop Team <securedrop@freedom.press>  Tue, 02 May 2023 16:53:12 +0000
+ -- SecureDrop Team <securedrop@freedom.press>  Wed, 03 May 2023 19:36:49 +0000
 
 securedrop-proxy (0.4.0+buster) unstable; urgency=medium
 


### PR DESCRIPTION
(draft pending completion of QA)

Refs <https://github.com/freedomofpress/securedrop-proxy/issues/116>.