### PR TITLE
Remove Debian autogenerated conffiles from securedrop-keyring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ build-wheels: ## Builds the wheels and adds them to the localwheels directory
 
 .PHONY: test
 test: ## Run simple test suite (skips reproducibility checks)
-	pytest -v tests/test_update_requirements.py
+	pytest -v tests/test_update_requirements.py tests/test_deb_package.py
 
 .PHONY: reprotest
 reprotest: ## Runs only reproducibility tests, for .deb and .whl files

--- a/securedrop-keyring/debian/rules
+++ b/securedrop-keyring/debian/rules
@@ -3,3 +3,10 @@
 %:
 	dh $@
 
+# Override debhelper's auto-generated files in `/etc/`
+# to force an exact replacement of the files we are modifying
+# there (specifically, `/etc/apt/trusted.gpg.d/securedrop-keyring.gpg`).
+override_dh_installdeb:
+	dh_installdeb
+	cat /dev/null > ${CURDIR}/debian/securedrop-keyring/DEBIAN/conffiles
+

--- a/tests/test_deb_package.py
+++ b/tests/test_deb_package.py
@@ -1,0 +1,33 @@
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+SECUREDROP_ROOT = Path(
+    subprocess.check_output(["git", "rev-parse", "--show-toplevel"]).decode().strip()
+)
+DEB_PATHS = list((SECUREDROP_ROOT / "build/debbuild/packaging").glob("*.deb"))
+
+@pytest.mark.parametrize("deb", DEB_PATHS)
+def test_securedrop_keyring_removes_conffiles(deb: Path):
+    """
+    Ensures additional conffiles are not shipped in the `securedrop-keyring`
+    package. Files in `/etc/` are automatically marked as conffiles during
+    packaging, so our build logic overwrites the additional files that would
+    be left behind in the `/etc/apt/trusted.gpg.d/` diretory.
+
+    When `securedrop-keyring.gpg` is shipped in `/usr/share/keyrings`, this
+    test can be removed.
+    """
+    if not deb.name.startswith(("securedrop-keyring")):
+        return
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        subprocess.check_call(["dpkg-deb", "--control", deb, tmpdir])
+        conffiles_path = Path(tmpdir) / "conffiles"
+        assert conffiles_path.exists()
+        # No files are currently allow-listed to be conffiles
+        assert conffiles_path.read_text().rstrip() == ""
+


### PR DESCRIPTION
Closes #450 

- Don't include conffiles for securedrop-keyring 
- Add deb test that tests this behaviour only for securedrop-keyring, and add test to `make tests` target

### Test plan
- In a debian-based vm, install seuredrop-keyring-0.1.7 from apt-test
- Build securedrop-keyring-0.2.0 deb from the tip of this branch, and install it using dpkg
- [x] deb installs successfully and no additional files are created in `/etc/apt/trusted.gpg.d/`
- [x] bonus: importing the new keyring to an as-yet-unsed gpg homedir (eg `gpg --homedir /tmp --import /etc/apt/trusted.gpg.d/securedrop-keyring.gpg`) shows only the 2024 expiry pubkey