### PR TITLE
Update build-requirements.txt path for securedrop-proxy package

### DIFF
--- a/securedrop-proxy/debian/rules
+++ b/securedrop-proxy/debian/rules
@@ -3,7 +3,8 @@
 %:
 	dh $@ --with python-virtualenv
 
-REQUIREMENTS_FILE=requirements/build-requirements.txt
+# For backwards compatibility; can be set to build-requirements.txt once fully switched to new path
+REQUIREMENTS_FILE=$(shell test -e build-requirements.txt && echo "build-requirements.txt" || echo "requirements/build-requirements.txt")
 
 override_dh_virtualenv:
 	test -e $(REQUIREMENTS_FILE)


### PR DESCRIPTION
This should be merged together with https://github.com/freedomofpress/securedrop-proxy/pull/122 and will fail until then.