### PR TITLE
Add backwards-compatible reference to new build-requirements.txt

### DIFF
--- a/securedrop-client/debian/rules
+++ b/securedrop-client/debian/rules
@@ -3,7 +3,8 @@
 %:
 	dh $@ --with python-virtualenv
 
-REQUIREMENTS_FILE=requirements/build-requirements.txt
+# For backwards compatibility; can be set to build-requirements.txt once fully switched to new path
+REQUIREMENTS_FILE=$(shell test -e build-requirements.txt && echo "build-requirements.txt" || echo "requirements/build-requirements.txt")
 
 override_dh_virtualenv:
 	test -e $(REQUIREMENTS_FILE)

--- a/securedrop-export/debian/rules
+++ b/securedrop-export/debian/rules
@@ -3,7 +3,8 @@
 %:
 	dh $@ --with python-virtualenv
 
-REQUIREMENTS_FILE=requirements/build-requirements.txt
+# For backwards compatibility; can be set to build-requirements.txt once fully switched to new path
+REQUIREMENTS_FILE=$(shell test -e build-requirements.txt && echo "build-requirements.txt" || echo "requirements/build-requirements.txt")
 
 override_dh_virtualenv:
 	test -e $(REQUIREMENTS_FILE)

--- a/securedrop-log/debian/rules
+++ b/securedrop-log/debian/rules
@@ -3,7 +3,8 @@
 %:
 	dh $@ --with python-virtualenv
 
-REQUIREMENTS_FILE=requirements/build-requirements.txt
+# For backwards compatibility; can be set to build-requirements.txt once fully switched to new path
+REQUIREMENTS_FILE=$(shell test -e build-requirements.txt && echo "build-requirements.txt" || echo "requirements/build-requirements.txt")
 
 override_dh_virtualenv:
 	test -e $(REQUIREMENTS_FILE)


### PR DESCRIPTION
This file will be moving to the repository root in the near future as part of our migration to poetry, making the packaging compatible with both eases the transition.