### PR TITLE
Fix issues around case-sensitive matching in poetry support

### DIFF
--- a/scripts/update-requirements
+++ b/scripts/update-requirements
@@ -52,9 +52,6 @@ def main():
             sys.exit(1)
 
     project = Path(__file__).parent.parent / project_name
-
-    # First remove index line and any PyQt or sip dependency
-
     if requirements_file.name == "poetry.lock":
         dependencies = utils.get_poetry_names_and_versions(
             requirements_file, pyproject_toml


### PR DESCRIPTION
poetry doesn't normalize case in package names, so in securedrop-client we have jinja2 depending on "MarkupSafe", but the package itself in the lock file is named "markupsafe".

We can avoid this by changing the relevant_dependencies to all be lowercase when reading them out of pyproject.toml (the "main" dependencies) and when reading from poetry.lock.

## Test plan

* [x] Running `PKG_DIR=../securedrop-proxy make requirements` results in no changes
* [x] repeat for sd-export
* [x] and for sd-log
* [x] and for sd-client with https://github.com/freedomofpress/securedrop-client/pull/1671 checked out