### PR TITLE
Cleanup old RPM nightlies too

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ common-steps:
       name: Commit workstation debs for deployment to apt-test.freedom.press
       command: |
         apt-get update
-        apt-get install -y ca-certificates git git-lfs openssh-client python3 python3-debian
+        apt-get install -y ca-certificates git git-lfs openssh-client python3 python3-debian python3-rpm
         git config --global user.email "securedrop@freedom.press"
         git config --global user.name "sdcibot"
 
@@ -327,17 +327,25 @@ jobs:
           name: Commit and push
           command: |
             apt-get update
-            apt-get install -y ca-certificates git git-lfs openssh-client
+            apt-get install -y ca-certificates git git-lfs openssh-client python3-rpm python3-debian
             git clone git@github.com:freedomofpress/securedrop-yum-test.git
             cd securedrop-yum-test
             git lfs install
             git config user.email "securedrop@freedom.press"
             git config user.name "sdcibot"
             mkdir -p workstation/dom0/f32-nightlies
+            # Copy the new packages over and cleanup the old ones
             cp -v /tmp/workspace/*.rpm workstation/dom0/f32-nightlies/
+            ~/project/scripts/clean-old-packages workstation/dom0/f32-nightlies 7
             git add .
-            # If there are changes, diff-index will fail, so we commit and push
-            git diff-index --quiet HEAD || git commit -m "Automated SecureDrop workstation build" && git push origin main
+            # If there are changes, diff-index will fail, so we commit
+            git diff-index --quiet HEAD || git commit -m "Automated SecureDrop workstation build"
+            # And clean up non-nightly packages too
+            ~/project/scripts/clean-old-packages workstation/dom0/f32 4
+            git add .
+            git diff-index --quiet HEAD || git commit -m "Cleanup old packages"
+
+            git push origin main
 
 
 workflows:

--- a/scripts/clean-old-packages
+++ b/scripts/clean-old-packages
@@ -13,17 +13,29 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Tuple
 
+import rpm
 from debian import debfile
 
 
-def sort_versions(one: Tuple[str, Path], two: Tuple[str, Path]):
+def sort_deb_versions(one: Tuple[str, Path], two: Tuple[str, Path]):
     """sort two Debian package versions"""
     status = subprocess.run(['dpkg', '--compare-versions', one[0], 'lt', two[0]])
     if status.returncode == 1:
-        # false, two is bigger
+        # false, one is bigger
         return 1
     else:
-        # true, one is bigger
+        # true, two is bigger
+        return -1
+
+
+def sort_rpm_versions(one: Tuple[str, Path], two: Tuple[str, Path]):
+    """sort two RPM package versions"""
+    status = subprocess.run(['rpmdev-vercmp', one[0], two[0]], stdout=subprocess.DEVNULL)
+    if status.returncode == 11:
+        # false, one is bigger
+        return 1
+    else:  # status.returncode == 12
+        # true, two is bigger
         return -1
 
 
@@ -45,6 +57,35 @@ def fix_name(name: str) -> str:
     return name
 
 
+def rpm_info(path: Path) -> Tuple[str, str]:
+    """
+    learned this incantation from <https://web.archive.org/web/20120911204323/http://docs.fedoraproject.org/en-US/Fedora_Draft_Documentation/0.1/html/RPM_Guide/ch16s05.html>
+    and help(headers)
+    """
+    ts = rpm.ts()
+    with path.open() as f:
+        headers = ts.hdrFromFdno(f)
+    return headers[rpm.RPMTAG_NAME], headers[rpm.RPMTAG_VERSION] + '-' + headers[rpm.RPMTAG_RELEASE]
+
+
+def cleanup(data, to_keep: int, sorter):
+    for name, versions in sorted(data.items()):
+        if len(versions) <= to_keep:
+            # Nothing to delete
+            continue
+        print(f'### {name}')
+        items = sorted(versions.items(), key=functools.cmp_to_key(sorter), reverse=True)
+        keeps = items[:to_keep]
+        print('Keeping:')
+        for _, keep in keeps:
+            print(f'* {keep.name}')
+        delete = items[to_keep:]
+        print('Deleting:')
+        for _, path in delete:
+            print(f'* {path.name}')
+            path.unlink()
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Cleans up old packages"
@@ -63,27 +104,18 @@ def main():
     if not args.directory.is_dir():
         raise RuntimeError(f"Directory, {args.directory}, doesn't exist")
     print(f'Only keeping the latest {args.keep} packages')
-    data = defaultdict(dict)
+    debs = defaultdict(dict)
+    rpms = defaultdict(dict)
     for deb in args.directory.glob('*.deb'):
         control = debfile.DebFile(deb).control.debcontrol()
         name = fix_name(control['Package'])
-        data[name][control['Version']] = deb
+        debs[name][control['Version']] = deb
+    for rpm in args.directory.glob('*.rpm'):
+        name, version = rpm_info(rpm)
+        rpms[name][version] = rpm
 
-    for name, versions in sorted(data.items()):
-        if len(versions) <= args.keep:
-            # Nothing to delete
-            continue
-        print(f'### {name}')
-        items = sorted(versions.items(), key=functools.cmp_to_key(sort_versions), reverse=True)
-        keeps = items[:args.keep]
-        print('Keeping:')
-        for _, keep in keeps:
-            print(f'* {keep.name}')
-        delete = items[args.keep:]
-        print('Deleting:')
-        for _, path in delete:
-            print(f'* {path.name}')
-            path.unlink()
+    cleanup(debs, args.keep, sort_deb_versions)
+    cleanup(rpms, args.keep, sort_rpm_versions)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Status

Ready for review, but needs https://github.com/freedomofpress/securedrop-yum-test/pull/51 to be merged first.

## Description

Extend the `clean-old-packages` script so it works for RPMs too. We use the Python RPM bindings to extract package name and version and then shell out to `rpmdev-vercmp` to sort them.

The behavior is now the same as the deb cleanup, when new nightly packages are pushed, it'll clean up old nightlies in the same commit. RC packages (in the `f32` component) will be cleaned up in a separate commit, if necessary.

Fixes #435.