### PR TITLE
Unbreak nightlies failing due to CircleCI behavior change

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,7 +237,6 @@ jobs:
     environment:
       NAME: << parameters.package >>
       PKG_NAME: securedrop-<< parameters.package >>
-      SCHEDULE_NAME: << pipeline.schedule.name >>
       IS_NIGHTLY: << parameters.nightly >>
     steps:
       - checkout


### PR DESCRIPTION
The `pipeline.schedule.name` variable now seems to be unset, causing nightlies to fail. We were not actually using `SCHEDULE_NAME` for anything, so this should be otherwise a noop.