### PR TITLE
Fix building of wheels in monorepo and update docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,9 @@ requirements: ## Creates requirements files for the Python projects
 
 .PHONY: build-wheels
 build-wheels: ## Builds the wheels and adds them to the wheels subdirectory
-	./scripts/verify-sha256sum-signature $$(basename ${PKG_DIR})
+	./scripts/verify-sha256sum-signature securedrop-$$(basename ${PKG_DIR})
 	./scripts/build-sync-wheels
-	./scripts/sync-sha256sums $$(basename ${PKG_DIR})
+	./scripts/sync-sha256sums securedrop-$$(basename ${PKG_DIR})
 	@echo Done!
 
 .PHONY: test


### PR DESCRIPTION
The main issue is that our previous hack to detect the component name from the folder no longer works, since it'll now be an unprefixed "client", so have the Makefile add the prefixing in.

Documentation has been updated as well.

Fixes #486.