### PR TITLE
Update ruff config format; apply latest fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,8 @@ requires-python = ">=3.9"
 
 [tool.ruff]
 line-length = 100
+
+[tool.ruff.lint]
 select = [
     # pycodestyle errors
     "E",

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -1,6 +1,7 @@
 """
 Shared functions between various scripts
 """
+
 import re
 
 try:


### PR DESCRIPTION
We're currently installing the latest version of `ruff` in CI without pinning. Until we change that, we'll have to keep up with upstream behavior changes. This PR does that - it updates the configuration format to silence a couple of deprecation warnings, and applies a small formatting change that a previous version did not catch.