### PR TITLE
fix: handle mismatch between a `dbgsym` package's extension and `buildinfo` record

### DIFF
--- a/scripts/check-buildinfo
+++ b/scripts/check-buildinfo
@@ -49,7 +49,7 @@ def check_package(package: Path, buildinfos: dict) -> bool:
         return False
 
 
-def added_files(against="origin/main") -> List[Path]:
+def added_files(against: str) -> List[Path]:
     """Get list of added files compared to main"""
     added = []
     output = subprocess.check_output([
@@ -79,10 +79,13 @@ def main():
         description="Check packages against their buildinfo files"
     )
     parser.add_argument("buildinfos", type=Path, help="Folder with buildinfo files")
+    parser.add_argument(
+        "--against", default="origin/main", type=str, help="Git ref from which to detect changes"
+    )
     args = parser.parse_args()
     buildinfos = lookup_buildinfos(args.buildinfos)
     status = 0
-    added = added_files()
+    added = added_files(args.against)
     if not added:
         print("No new packages detected.")
         sys.exit(0)

--- a/scripts/check-buildinfo
+++ b/scripts/check-buildinfo
@@ -6,6 +6,7 @@ Example:
     ./check-buildinfo package.deb package.buildinfo
 
 """
+
 import argparse
 import hashlib
 import subprocess
@@ -21,15 +22,15 @@ def lookup_buildinfos(buildinfos: Path) -> dict:
     data = {}
     for path in buildinfos.glob("**/*.buildinfo"):
         info = BuildInfo(path.read_text())
-        for details in info['Checksums-Sha256']:
-            if details['name'].endswith('.deb') or details['name'].endswith('.ddeb'):
+        for details in info["Checksums-Sha256"]:
+            if details["name"].endswith(".deb") or details["name"].endswith(".ddeb"):
                 # If the package is debug symbols, coerce Ubuntu-style ".ddeb"
                 # to Debian-style ".deb".
-                if "dbgsym" in details['name']:
-                    details['name'] = details['name'].replace(".ddeb", ".deb")
-                if details['name'] in data:
+                if "dbgsym" in details["name"]:
+                    details["name"] = details["name"].replace(".ddeb", ".deb")
+                if details["name"] in data:
                     raise ValueError(f"ERROR: duplicate checksum for {details['name']}")
-                data[details['name']] = details['sha256']
+                data[details["name"]] = details["sha256"]
     return data
 
 
@@ -52,21 +53,25 @@ def check_package(package: Path, buildinfos: dict) -> bool:
 def added_files(against: str) -> List[Path]:
     """Get list of added files compared to main"""
     added = []
-    output = subprocess.check_output([
-        "git", "log",
-        # Only list added files
-        "--diff-filter=A",
-        # Set our terminal width to be huge so it doesn't truncate
-        "--stat=999999",
-        # Output nothing else
-        "--pretty=",
-        f"{against}..HEAD"
-    ], text=True)
+    output = subprocess.check_output(
+        [
+            "git",
+            "log",
+            # Only list added files
+            "--diff-filter=A",
+            # Set our terminal width to be huge so it doesn't truncate
+            "--stat=999999",
+            # Output nothing else
+            "--pretty=",
+            f"{against}..HEAD",
+        ],
+        text=True,
+    )
     for line in output.splitlines():
         if "|" not in line:
             continue
         path = Path(line.split("|", 1)[0].strip())
-        if path.name.endswith('.deb') or path.name.endswith(".ddeb"):
+        if path.name.endswith(".deb") or path.name.endswith(".ddeb"):
             if path.exists():
                 # Wasn't deleted in an intermediate commit
                 added.append(path)
@@ -75,9 +80,7 @@ def added_files(against: str) -> List[Path]:
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        description="Check packages against their buildinfo files"
-    )
+    parser = argparse.ArgumentParser(description="Check packages against their buildinfo files")
     parser.add_argument("buildinfos", type=Path, help="Folder with buildinfo files")
     parser.add_argument(
         "--against", default="origin/main", type=str, help="Git ref from which to detect changes"
@@ -95,5 +98,5 @@ def main():
     sys.exit(status)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/scripts/check-buildinfo
+++ b/scripts/check-buildinfo
@@ -22,7 +22,11 @@ def lookup_buildinfos(buildinfos: Path) -> dict:
     for path in buildinfos.glob("**/*.buildinfo"):
         info = BuildInfo(path.read_text())
         for details in info['Checksums-Sha256']:
-            if details['name'].endswith('.deb'):
+            if details['name'].endswith('.deb') or details['name'].endswith('.ddeb'):
+                # If the package is debug symbols, coerce Ubuntu-style ".ddeb"
+                # to Debian-style ".deb".
+                if "dbgsym" in details['name']:
+                    details['name'] = details['name'].replace(".ddeb", ".deb")
                 if details['name'] in data:
                     raise ValueError(f"ERROR: duplicate checksum for {details['name']}")
                 data[details['name']] = details['sha256']
@@ -62,9 +66,10 @@ def added_files(against="origin/main") -> List[Path]:
         if "|" not in line:
             continue
         path = Path(line.split("|", 1)[0].strip())
-        if path.name.endswith('.deb') and path.exists():
-            # Wasn't deleted in an intermediate commit
-            added.append(path)
+        if path.name.endswith('.deb') or path.name.endswith(".ddeb"):
+            if path.exists():
+                # Wasn't deleted in an intermediate commit
+                added.append(path)
     added.sort(key=lambda x: x.name)
     return added
 


### PR DESCRIPTION
Fixes #504 by matching on both Ubuntu-style `.ddeb` and Debian-style `.deb` extensions for `dbgsym` packages, but always use the latter for lookup.

Incidentally adds an `--against $REF` argument and formats with ruff.


## Testing

Something like:

```sh-session
$ cd ~/securedrop-builder
$ git fetch
$ git checkout 504-ubuntu-dbgsym
$ cd ~/build-logs
$ git pull
$ cd ~/securedrop-apt-test
$ git pull
$ ~/securedrop-builder/scripts/check-buildinfo --against HEAD~2 ~/build-logs/ | grep "dbgsym"
OK: got expected checksum 2d3d6e6e5d551dbe9aa59df2179b41a65a180d986bd5919df0a329a56c238c50 for securedrop-app-code-dbgsym_2.11.0~rc1+focal_amd64.deb
OK: got expected checksum af4ef1de1ed3d3572077cd4a7adf9f82e5cb878676714dba15f7e0517f5bc9e2 for securedrop-config-dbgsym_2.11.0~rc1+focal_amd64.deb
```