### PR TITLE
Lint our GitHub Actions workflows with zizmor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
             python3-poetry
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           lfs: true
       - name:  Install additional packages and Python dependencies
         run: |
@@ -34,6 +35,7 @@ jobs:
           apt-get update && apt-get install --yes --no-install-recommends make git git-lfs gnupg ca-certificates
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           lfs: true
       - name: Verify checksums and signatures
         run: |

--- a/.github/workflows/reprotest.yml
+++ b/.github/workflows/reprotest.yml
@@ -19,6 +19,7 @@ jobs:
             python3-poetry
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           lfs: true
       - name:  Install additional packages and Python dependencies
         run: |

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ SHELL := /bin/bash
 lint:
 	@poetry run ruff check .
 	@poetry run ruff format --check .
+	@poetry run zizmor .
 
 .PHONY: fix
 fix:

--- a/poetry.lock
+++ b/poetry.lock
@@ -123,7 +123,30 @@ files = [
     {file = "virtualenv-15.2.0.tar.gz", hash = "sha256:1d7e241b431e7afce47e77f8843a276f652699d1fa4f93b9d8ce0076fd7b0b54"},
 ]
 
+[[package]]
+name = "zizmor"
+version = "1.0.0"
+description = "Static analysis for GitHub Actions"
+optional = false
+python-versions = "*"
+files = [
+    {file = "zizmor-1.0.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:d8296b8044160fc5ae0558bdd4781d0479b65e11a54ba68ea6abff31f440adfb"},
+    {file = "zizmor-1.0.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:49f1837b704ce83d5618e9ac222359c60fb4db1e9100ff2045bdf298b66b5e95"},
+    {file = "zizmor-1.0.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ff88090aca8dc769c0272ed0500c08bf52daa328f5b96b83f41622bb84dad6dd"},
+    {file = "zizmor-1.0.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c33d137254f048654eed8904882ce5d91a266d7a510c71f027cbde53b956c6e1"},
+    {file = "zizmor-1.0.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b771e6c497def0017358fcdc6f796c16a144d382e9bdaeb31e49ae74c3383c3f"},
+    {file = "zizmor-1.0.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd5708db1193c0a4285a914aee0cb17181b228d95e3521c6f01f98b2a6010023"},
+    {file = "zizmor-1.0.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e235a8d7e93a7a21bc5901844aba7eaf3ec40ef7dee1ed74210b78a54d18ae5a"},
+    {file = "zizmor-1.0.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4074447e1073209197366f8fd96727fc225dc3524e2b859da4a3b8665f002eff"},
+    {file = "zizmor-1.0.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:7ad15ce7c9c3a45a84ddf0bb48c40390785f406366605613fd7bd44c4990e418"},
+    {file = "zizmor-1.0.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:7ed030c1f71105773d335636821c6f5b571b17ea43d3e3c8b0e3c2f95658ac88"},
+    {file = "zizmor-1.0.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:839347e4152807438da7a7d328f765eb0429c13aadd0164469f3a642608410e5"},
+    {file = "zizmor-1.0.0-py3-none-win32.whl", hash = "sha256:bd1892ea25129514e0dc37a54a9c41103458c831dcea9219814a6f0396d89d5e"},
+    {file = "zizmor-1.0.0-py3-none-win_amd64.whl", hash = "sha256:155b790beb3255112671c01ac502f017616b5ba04e85e5882cad3f57e11be927"},
+    {file = "zizmor-1.0.0.tar.gz", hash = "sha256:2a7c49e9c68722e2a84b2456c45ee6c70629ba423251907cf03a10d6160f5754"},
+]
+
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11"
-content-hash = "459c206d77063634259276ff35c57fcac9f8eb9c7f0c770e72b2a9a1a7a3bbdf"
+content-hash = "90fb297b0608a24c48fecbc4e63bb47e3b75084eaec2b65dfd48b708698a0eeb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ pytest = "*"
 pytest-mock = "*"
 ruff = "*"
 virtualenv = "<16"
+zizmor = "^1.0.0"
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
_**Note**: this depends on https://github.com/freedomofpress/securedrop-builder/pull/506, which should be merged first_

We just need to set `persist-credentials: false` in all of our workflows.

Refs <freedomofpress/securedrop-tooling#18>.